### PR TITLE
Renamed events to new typeahead 0.11.1 api names and added new functionality.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+/.vs/config/applicationhost.config

--- a/README.md
+++ b/README.md
@@ -19,216 +19,246 @@ Download Typeahead.js for MVC 5 Models using [NuGet](https://www.nuget.org/packa
 
 1.	Edit ~\Views\Shared\_Layout.cshtml to load the typeahead.js bundle, Typeahead stylesheet and javascript that connects Typeahead to your MVC 5 model
 
-	a.	Add the line to load the Typeahead stylesheet
-	In ~\Views\Shared\_Layout.cshtml, add the following line before the close of the head tag:
+    a.	Add the line to load the Typeahead stylesheet
+    In ~\Views\Shared\_Layout.cshtml, add the following line before the close of the head tag:
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/typeahead_css.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/typeahead_css.png)
 
-	````html
-	<link rel="stylesheet" type="text/css" href="~/Content/typeahead.css" />
-	````
+    ````html
+    <link rel="stylesheet" type="text/css" href="~/Content/typeahead.css" />
+    ````
 
-	b.	Add the line to load the Typeahead MVC bundle javascript and Typeahead MVC Model javascript (that connects Typeahead to your MVC model):
+    b.	Add the line to load the Typeahead MVC bundle javascript and Typeahead MVC Model javascript (that connects Typeahead to your MVC model):
 
-	In ~\Views\Shared\_Layout.cshtml, add the following line after jquery and bootstrap are both loaded:
+    In ~\Views\Shared\_Layout.cshtml, add the following line after jquery and bootstrap are both loaded:
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/typeahead_bundle.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/typeahead_bundle.png)
 
-	````html
-		@Scripts.Render("~/bundles/typeahead")
-		<script src="~/Scripts/typeahead.mvc.model.js" />
-	````    
+    ````html
+        @Scripts.Render("~/bundles/typeahead")
+        <script src="~/Scripts/typeahead.mvc.model.js" />
+    ````    
     
 2.	Add a new Model to your project
 
-	a.	Right-click on the Models folder and choose Add > New Item…
+    a.	Right-click on the Models folder and choose Add > New Item…
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/new_item.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/new_item.png)
 
-	b.	For the Name, type HelloWorld.cs and click Add
+    b.	For the Name, type HelloWorld.cs and click Add
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_helloworld.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_helloworld.png)
 
-	c.	In the Editor, add 4 new properties to the class. Hit F6 to Save and Build your project
+    c.	In the Editor, add 4 new properties to the class. Hit F6 to Save and Build your project
 
-	````c#
-			public int HelloWorldId { get; set; }
-			public string Message { get; set; }
-			public string Person { get; set; }
-			public int PersonId { get; set; }
-	````
+    ````c#
+            public int HelloWorldId { get; set; }
+            public string Message { get; set; }
+            public string Person { get; set; }
+            public int PersonId { get; set; }
+    ````
 
 3. Add the Entity Framework for AdventureWorks2012 to your project.
 
-	a.	Right-click on your project and choose Add > New Item…
+    a.	Right-click on your project and choose Add > New Item…
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/new_item.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/new_item.png)
 
-	b.	Choose “ADO.NET Entity Data Model”. For Name, type “AWModel.” Click Add
+    b.	Choose “ADO.NET Entity Data Model”. For Name, type “AWModel.” Click Add
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_entity_data_model.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_entity_data_model.png)
 
-	c.	Choose “EF Designer from data…” Click Next >
+    c.	Choose “EF Designer from data…” Click Next >
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/choose_model_contents.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/choose_model_contents.png)
 
-	d.	Click New Connection…
+    d.	Click New Connection…
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/new_connection.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/new_connection.png)
 
-	e.	For Server name, type the name of the server you attached the AdventureWorks2012 database to. For “Select or enter a database name”, choose AdventureWorks2012. Click Ok
+    e.	For Server name, type the name of the server you attached the AdventureWorks2012 database to. For “Select or enter a database name”, choose AdventureWorks2012. Click Ok
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/connection_properties.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/connection_properties.png)
 
-	f.	For “Save connection settings in Web.Config as”, type AWEntities. Click Next >
+    f.	For “Save connection settings in Web.Config as”, type AWEntities. Click Next >
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/awentities.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/awentities.png)
 
-	g.	Expand Tables and Person. Choose Person. For Model Namespace, type AWModel. Click Finish
+    g.	Expand Tables and Person. Choose Person. For Model Namespace, type AWModel. Click Finish
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/choose_person.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/choose_person.png)
 
-	h.	For some reason, Entity Framework does not like it when an entity’s primary key does not match the entity name. To fix this, open up AWModel.edmx
+    h.	For some reason, Entity Framework does not like it when an entity’s primary key does not match the entity name. To fix this, open up AWModel.edmx
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/awmodel_edmx.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/awmodel_edmx.png)
 
-	i.	Rename the BusinessEntityId column to PersonId. Hit F6 to Save and Build your project
+    i.	Rename the BusinessEntityId column to PersonId. Hit F6 to Save and Build your project
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/personid.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/personid.png)
 
 4.	Add a new Scaffolded Item to your project
 
-	a.	Right-click on the Controllers folder and choose Add > New Scaffolded Item…
+    a.	Right-click on the Controllers folder and choose Add > New Scaffolded Item…
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_new_scaffolded.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_new_scaffolded.png)
 
-	b.	Choose “MVC 5 Controller with views, using Entity Framework”. Click Add
+    b.	Choose “MVC 5 Controller with views, using Entity Framework”. Click Add
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_scaffold.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_scaffold.png)
 
-	c.	For the Model class, choose HelloWorld ([Project Name].Models). For the Data context class, choose the data context you created earlier, AWEntities ([Project Name]). For the Controller name, HelloWorldController. Click Add
+    c.	For the Model class, choose HelloWorld ([Project Name].Models). For the Data context class, choose the data context you created earlier, AWEntities ([Project Name]). For the Controller name, HelloWorldController. Click Add
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_controller.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/add_controller.png)
 
-	*You now have a Controller, Model and View. It’s time to get to work!*
+    *You now have a Controller, Model and View. It’s time to get to work!*
 
 5.	Add code to the HelloWorldController to get people from the database
 
-	a.	Open up HelloWorldController.cs
+    a.	Open up HelloWorldController.cs
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/helloworldcontroller_cs.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/helloworldcontroller_cs.png)
 
-	b.	Near the top of the file, add the using statements for Entity Framework exceptions:
+    b.	Near the top of the file, add the using statements for Entity Framework exceptions:
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/entity_core.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/entity_core.png)
 
-	````c#
-	using System.Data.Entity.Core;
-	````
+    ````c#
+    using System.Data.Entity.Core;
+    ````
 
-	c.	Add code to get people out of the AdventureWorks2012 database using Entity Framework:
+    c.	Add code to get people out of the AdventureWorks2012 database using Entity Framework:
 
-	````c#
-	private List<Autocomplete> _GetPeople(string query)
-	{
-		List<Autocomplete> people = new List<Autocomplete>();
-		try
-		{
-			var results = (from p in db.People
-							where (p.FirstName + " " + p.LastName).Contains(query)
-							orderby p.FirstName,p.LastName
-							select p).Take(10).ToList();
-			foreach (var r in results)
-			{
-				// create objects
-				Autocomplete person = new Autocomplete();
+    ````c#
+    private List<Autocomplete> _GetPeople(string query)
+    {
+        List<Autocomplete> people = new List<Autocomplete>();
+        try
+        {
+            var results = (from p in db.People
+                            where (p.FirstName + " " + p.LastName).Contains(query)
+                            orderby p.FirstName,p.LastName
+                            select p).Take(10).ToList();
+            foreach (var r in results)
+            {
+                // create objects
+                Autocomplete person = new Autocomplete();
 
-				person.Name = string.Format("{0} {1}", r.FirstName, r.LastName);
-				person.Id = r.PersonId;
-				people.Add(person);
-			}
+                person.Name = string.Format("{0} {1}", r.FirstName, r.LastName);
+                person.Id = r.PersonId;
+                people.Add(person);
+            }
 
-		}
-		catch (EntityCommandExecutionException eceex)
-		{
-			if (eceex.InnerException != null)
-			{
-				throw eceex.InnerException;
-			}
-			throw;
-		}
-		catch
-		{
-			throw;
-		}
-		return people;
-	}
-	````
+        }
+        catch (EntityCommandExecutionException eceex)
+        {
+            if (eceex.InnerException != null)
+            {
+                throw eceex.InnerException;
+            }
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+        return people;
+    }
+    ````
 
-	d.	Add code to return the people in JSON format:
+    d.	Add code to return the people in JSON format:
 
-	````c#
-	public ActionResult GetPeople(string query)
-	{
-		return Json(_GetPeople(query), JsonRequestBehavior.AllowGet);
-	}
-	````        
+    ````c#
+    public ActionResult GetPeople(string query)
+    {
+        return Json(_GetPeople(query), JsonRequestBehavior.AllowGet);
+    }
+    ````        
         
 6. Add the Autocomplete (textahead) control to the Create view for the HelloWorld model
 
-	a. Open up ~\Views\HelloWorld\Create.cshtml.
+    a. Open up ~\Views\HelloWorld\Create.cshtml.
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/create_cshtml.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/create_cshtml.png)
 
-	b. Add a using statement after the @model line at the top of the file so our HtmlHelper is available in the View:
+    b. Add a using statement after the @model line at the top of the file so our HtmlHelper is available in the View:
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/cshtml_using.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/cshtml_using.png)
 
-	````html
-	@using WebApplication2.Models
-	````
+    ````html
+    @using WebApplication2.Models
+    ````
 
-	c.	Since we are hiding the PersonId, we can remove the following code from the View:
+    c.	Since we are hiding the PersonId, we can remove the following code from the View:
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/remove.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/remove.png)
 
-	d.	Add the PersonId property to the view, yet hide it. This property will be auto-populated by javascript after the user selects a typeahead value
+    d.	Add the PersonId property to the view, yet hide it. This property will be auto-populated by javascript after the user selects a typeahead value
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/hidden_personid.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/hidden_personid.png)
 
-	````
-	@Html.HiddenFor(model => model.PersonId)
-	````
+    ````
+    @Html.HiddenFor(model => model.PersonId)
+    ````
 
-	e.	We need to change the control from EditorFor to AutocompleteFor. We also need to specify the property name, property key field, the method that Typeahead will call to get the lookup values and keys. The last parameter is false which will keep this field from stealing the focus when the page is loaded.
+    e.	We need to change the control from EditorFor to AutocompleteFor. We also need to specify the property name, property key field, the method that Typeahead will call to get the lookup values and keys. The last parameter is false which will keep this field from stealing the focus when the page is loaded.
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/autocompletefor.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/autocompletefor.png)
 
-	````html
-	@Html.AutocompleteFor(model => model.Name, model => model.PersonId, "GetPeople", "HelloWorld", false)
-	````
+    ````html
+    @Html.AutocompleteFor(model => model.Name, model => model.PersonId, "GetPeople", "HelloWorld", false)
+    ````
 
 7.	Test things out to see how they work
 
-	a.	In HelloWorldController, set a breakpoint in the second Create() (under the [HttpPost] declaration) to inspect the results returned from web page after we test out Typeahead
+    a.	In HelloWorldController, set a breakpoint in the second Create() (under the [HttpPost] declaration) to inspect the results returned from web page after we test out Typeahead
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/breakpoint.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/breakpoint.png)
 
-	b.	Open up Create.cshtml again and hit F5 to test things out
+    b.	Open up Create.cshtml again and hit F5 to test things out
 
-	c.	For Message, type “Hello World!” For Name, type “Anna.” It might take a second or two but the list will populate with the top 10 matches. Choose “Anna Albright” Click Create
+    c.	For Message, type “Hello World!” For Name, type “Anna.” It might take a second or two but the list will populate with the top 10 matches. Choose “Anna Albright” Click Create
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/preview.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/preview.png)
 
-	d. This should hit the breakpoint you set on Create()
+    d. This should hit the breakpoint you set on Create()
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/breakpoint_hit.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/breakpoint_hit.png)
 
-	e.	Notice that, in your breakpoint, if you expand “helloWorld”, that PersonId is automatically set to 325. Neat, huh?
+    e.	Notice that, in your breakpoint, if you expand “helloWorld”, that PersonId is automatically set to 325. Neat, huh?
 
-	![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/watch.png)
+    ![Alt text](https://raw.githubusercontent.com/timdwilson/typeahead-mvc-model/master/doc/images/watch.png)
 
 **I will leave it to you to implement writing helloWorld back at to a database. This is an example after all :) Happy coding!**
 
 ##[Download](https://github.com/timdwilson/typeahead-mvc-model/blob/master/example/TypeaheadMvcModelExampleApp.zip?raw=true) the example application.
 
+***NOTES:***
+
+You can add any additional htmlAttributes which will be merged into the INPUT tag as well as the following "special" attributes
+
+Any event on the typeahead object can be bound by specifying a data-typeahead-*eventname* attribute containing the name of the javascript function to bind to the event.
+If the function specified in the attribute exists then it will be bound to the typeahead object during initialisation.
+
+1. For instance to bind the typeahead:select event an attribute with the name *data-typeahead-select* can be used to specify a javascript callback function that will be called after the internal typeahead-mvc-model onselected function has executed which sets the selected id value on the id field. The callback function has to have the same signature as the typeahead:select event handler: OnSelectedFunctionName(event)
+
+    Example:
+
+    ````html
+    @Html.AutocompleteFor(model => model.Name, model => model.PersonId, "GetPeople", "HelloWorld", false, new { htmlAttributes = new { @class = "form-control", data_typeahead_select = "OnSelectedFunctionName" } })
+    ````
+    With the javascript function defined as:
+    ````html
+    <script type="application/javascript">
+        function OnSelectedFunctionName(event)
+        {
+            //The default datum provided by this plugin has an id and name attribute
+            var obj$ = $(event.target);
+            var datum = {
+                            id: $('#' + obj$.data("autocomplete-id-field")).val(),
+                            value: event.target.value
+                        };
+            //Handle the selection value here//
+        }
+    </script>
+    ````
+2. Refer to the typeahead page for event names and their signatures that can be bound this way: [typeahead custom-events](https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#custom-events)

--- a/TypeaheadMvcModel/Controllers/HtmlHelpers.cs.pp
+++ b/TypeaheadMvcModel/Controllers/HtmlHelpers.cs.pp
@@ -45,7 +45,7 @@ namespace $rootnamespace$.Models
                 idFieldString += string.Format("_{0}_", index);
             }
 
-            return CreateTextBoxForFromAutocompleteFor<TModel, TProperty1, TProperty2>(html, valueExpression, actionName, controllerName, requestFocus, idFieldString, new object { });;
+            return CreateTextBoxForFromAutocompleteFor<TModel, TProperty1, TProperty2>(html, valueExpression, actionName, controllerName, requestFocus, idFieldString, additionalViewData);;
         }
 
         private static MvcHtmlString CreateTextBoxForFromAutocompleteFor<TModel, TProperty1, TProperty2>(
@@ -65,52 +65,62 @@ namespace $rootnamespace$.Models
             string autocompleteIdField = idFieldString.Substring(loc + 1, idFieldString.Length - loc - 1)
                 .Replace('.', '_');
 
-            dynamic htmlAttributes = new ExpandoObject();
+            var additionalViewDataDictionary = HtmlHelper.ObjectToDictionary(additionalViewData);
+            RouteValueDictionary defaultHtmlAttributes = new RouteValueDictionary();
+            defaultHtmlAttributes.Add("class", "typeahead");
+            defaultHtmlAttributes.Add("data-autocomplete-url", autocompleteUrl);
+            defaultHtmlAttributes.Add("data-autocomplete-id-field", autocompleteIdField);
 
-            // handle additional view data
-            if (additionalViewData != null)
+            IDictionary<string, object> htmlAttributes = new RouteValueDictionary();
+            if (additionalViewDataDictionary.ContainsKey("htmlAttributes"))
             {
-                var additionalViewDataPropertyNamesAndValues = additionalViewData.GetType()
-                    .GetProperties()
-                    .Where(pi => pi.GetGetMethod() != null)
-                    .Select(pi => new
-                    {
-                        Name = pi.Name,
-                        Value = pi.GetGetMethod().Invoke(additionalViewData, null)
-                    });
+                htmlAttributes = HtmlHelper.AnonymousObjectToHtmlAttributes(additionalViewDataDictionary["htmlAttributes"]);
+            }
+            htmlAttributes = html.MergeHtmlAttributes(htmlAttributes, defaultHtmlAttributes);
 
-                foreach (var pair in additionalViewDataPropertyNamesAndValues)
+            return html.TextBoxFor(valueExpression, htmlAttributes);
+        }
+        public static IDictionary<string, object> MergeHtmlAttributes(this HtmlHelper helper, object htmlAttributesObject, object defaultHtmlAttributesObject)
+        {
+            var concatKeys = new string[] { "class" };
+
+            var htmlAttributesDict = htmlAttributesObject as IDictionary<string, object>;
+            var defaultHtmlAttributesDict = defaultHtmlAttributesObject as IDictionary<string, object>;
+
+            RouteValueDictionary htmlAttributes = (htmlAttributesDict != null)
+                ? new RouteValueDictionary(htmlAttributesDict)
+                : HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributesObject);
+            RouteValueDictionary defaultHtmlAttributes = (defaultHtmlAttributesDict != null)
+                ? new RouteValueDictionary(defaultHtmlAttributesDict)
+                : HtmlHelper.AnonymousObjectToHtmlAttributes(defaultHtmlAttributesObject);
+
+            foreach (var item in htmlAttributes)
+            {
+                if (concatKeys.Contains(item.Key) && defaultHtmlAttributes.ContainsKey(item.Key))
                 {
-                    if (pair.Name == "htmlAttributes")
-                    {
-
-                        var htmlAttributesPropertyNamesAndValues = pair.Value.GetType()
-                            .GetProperties()
-                            .Where(pi => pi.PropertyType == typeof (string) && pi.GetGetMethod() != null)
-                            .Select(pi => new
-                            {
-                                Name = pi.Name,
-                                Value = pi.GetGetMethod().Invoke(pair.Value, null)
-                            });
-                        foreach (var pair2 in htmlAttributesPropertyNamesAndValues)
-                        {
-                            ((IDictionary<string, object>) htmlAttributes).Add(pair2.Name, pair2.Value);
-                        }
-                    }
+                    //If the existing value is not null and is not a blank string then concatenate the value else overwrite the value.
+                    defaultHtmlAttributes[item.Key] = (defaultHtmlAttributes[item.Key] != null && !string.IsNullOrEmpty(defaultHtmlAttributes[item.Key].ToString()))
+                        //Add the passed in values to the back of the default concat values
+                        ? string.Format("{0} {1}", defaultHtmlAttributes[item.Key], item.Value)
+                        //use the passed in value as is
+                        : item.Value;
+                }
+                else
+                {
+                    defaultHtmlAttributes.MergeAttribute(item.Key, item.Value);
                 }
             }
-            // add @class if it is not there yet
-            if (!((IDictionary<string, object>) htmlAttributes).ContainsKey("@class"))
-            {
-                htmlAttributes.@class = "";
-            }
 
-            string @class = (!((string) htmlAttributes.@class).Contains("typeahead") ? "typeahead" : "");
-            ((IDictionary<string, object>) htmlAttributes).Add("data-autocomplete-url", autocompleteUrl);
-            ((IDictionary<string, object>)htmlAttributes).Add("data-autocomplete-id-field", autocompleteIdField);
-            htmlAttributes.@class += (!string.IsNullOrEmpty(htmlAttributes.@class) ? " " : "") + @class;
-
-            return html.TextBoxFor(valueExpression, ((IDictionary<string, object>)htmlAttributes));
+            return defaultHtmlAttributes;
+        }
+        public static void MergeAttribute(this IDictionary<string, object> attributes, string name, object value)
+        {
+            if (attributes.Keys.Contains(name))
+                //Overwrite the existing value
+                attributes[name] = value;
+            else
+                //Add a new value
+                attributes.Add(name, value);
         }
     }
 }

--- a/TypeaheadMvcModel/Models/Autocomplete.cs.pp
+++ b/TypeaheadMvcModel/Models/Autocomplete.cs.pp
@@ -9,7 +9,7 @@ namespace $rootnamespace$.Models
 {
     public class Autocomplete
     {
-        public int Id { get; set;}
+        public string Id { get; set;}
 
         public string Name { get; set; }
     }

--- a/TypeaheadMvcModel/Scripts/typeahead.mvc.model.js
+++ b/TypeaheadMvcModel/Scripts/typeahead.mvc.model.js
@@ -1,4 +1,4 @@
-﻿$(document).ready($(function () {
+﻿$(document).ready(function () {
 
     function autocompletewrapper(obj) {
         var autos = new Bloodhound({
@@ -9,7 +9,7 @@
             remote: {
                 wildcard: "%QUERY",
                 url: $(obj).data("autocomplete-url") + "?query=%QUERY",
-                filter: function (autos) {
+                transform: function (autos) {
                     // Map the remote source JSON array to a JavaScript object array
                     return $.map(autos, function (auto) {
                         return {
@@ -19,16 +19,34 @@
                     });
                 }
             },
-            limit: 1000
+            identify: function (datum) {
+                return datum.id;
+            },
+            limit: 10
         });
 
         autos.initialize();
 
-        $(obj).typeahead({ highlight: true, minLength: 0, hint: true }, {
-            name: 'autos', displayKey: 'value', source: autos.ttAdapter()
-        }).on('typeahead:selected', function (obj, datum) {
+        $(obj).typeahead({ highlight: true, minLength: 3, hint: true }, {
+            name: 'autos', displayKey: 'value', source: autos
+        }).on('typeahead:select', function (obj, datum) {
             onselected(obj, datum);
         });
+
+        //Check if a change callback was requested and bind it if it exists
+        var trigger$ = $(obj);
+        bindEvent(trigger$, 'typeahead:active');
+        bindEvent(trigger$, 'typeahead:idle');
+        bindEvent(trigger$, 'typeahead:open');
+        bindEvent(trigger$, 'typeahead:close');
+        bindEvent(trigger$, 'typeahead:change');
+        bindEvent(trigger$, 'typeahead:render');
+        bindEvent(trigger$, 'typeahead:select');
+        bindEvent(trigger$, 'typeahead:autocomplete');
+        bindEvent(trigger$, 'typeahead:cursorchange');
+        bindEvent(trigger$, 'typeahead:asyncrequest');
+        bindEvent(trigger$, 'typeahead:asynccancel');
+        bindEvent(trigger$, 'typeahead:asyncreceive');
 
         if ($(obj).hasClass("focus")) {
             $(obj).focus();
@@ -38,12 +56,50 @@
 
     function onselected(obj, datum) {
         if (!obj || !obj.target || !datum) return;
-        $('#' + jQuery(obj.target).data("autocomplete-id-field")).val(datum.id.toString());
+        $('#' + $(obj.target).data("autocomplete-id-field")).val(datum.id.toString());
     }
 
-    $('*[data-autocomplete-url]')
+    //Binds event callbacks passed as attributes on the trigger element
+    //by convention searching for a data-event-name attribute and binding
+    //to the function of the same name of it exists as a function
+    //So by passing an attribute called data-typeahead-change the 
+    //typeahead:change event can be bound
+    function bindEvent(trigger$, eventName) {
+        var eventAttribute = eventName.replace(':', '-');
+        var _func = getFuncFromString(trigger$.data(eventAttribute));
+        if (_func)
+            trigger$.on(eventName, _func);
+    }
+
+    /**
+    From: http://stackoverflow.com/a/29947151/1085715
+    * Converts a string containing a function or object method name to a function pointer.
+    * @param  string   func
+    * @return function
+    */
+    function getFuncFromString(func) {
+        // if already a function, return
+        if (typeof func === 'function') return func;
+
+        // if string, try to find function or method of object (of "obj.func" format)
+        if (typeof func === 'string') {
+            if (!func.length) return null;
+            var target = window;
+            var func = func.split('.');
+            while (func.length) {
+                var ns = func.shift();
+                if (typeof target[ns] === 'undefined') return null;
+                target = target[ns];
+            }
+            if (typeof target === 'function') return target;
+        }
+
+        // return null if could not parse
+        return null;
+    }
+
+    $('input[class~="typeahead"][data-autocomplete-url]')
             .each(function () {
                 autocompletewrapper($(this));
             });
-})
-)
+});


### PR DESCRIPTION
Hallo Tim,

I like your idea for the MVC Model integration on the typeahead plugin, and have made some enhancements which you can add is you like.

The following was added or updated:
1. Added binding logic for additional events through data-api. The use can now alos bind their own select event without breaking existing functions.
2. Added identify function.
3. Changed defaults on typeahead to start searching remote after 3 characters to save postbacks and limit results returned. (This can maybe be set through the data-api as well?)
4. Added description of new methods in readme.md
5. Changed id on Autocomplete to a string to allow wider use of object ids, including guids, and string keys.
6. Fixed issue in HtmlHelpers that did not pass htmlAttributes along (line 48).
7. Added HtmlHelper methods to simplify the html attribute merging by using built-in functions (line 68-81)

Let me know what you think.

Kind Regards,
Francois Grobler
